### PR TITLE
Observer pattern

### DIFF
--- a/src/Behavioural/Observer/Notifications/BaseObserver.php
+++ b/src/Behavioural/Observer/Notifications/BaseObserver.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace levijackson\Pattern\Behavioural\Observer\Notifications;
+
+use SplObserver;
+use SplSubject;
+
+abstract class BaseObserver implements SplObserver {
+
+    const STATUS_SENT = 1;
+    const STATUS_NOT_SENT = 0;
+
+    protected $status = self::STATUS_NOT_SENT;
+
+    public function getStatus(): int {
+        return $this->status;
+    }
+
+    public function update(SplSubject $subject): void {
+        $this->status = self::STATUS_SENT;
+    }
+}

--- a/src/Behavioural/Observer/Notifications/EmailObserver.php
+++ b/src/Behavioural/Observer/Notifications/EmailObserver.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace levijackson\Pattern\Behavioural\Observer\Notifications;
+
+class EmailObserver extends BaseObserver {
+
+}

--- a/src/Behavioural/Observer/Notifications/NotifySubject.php
+++ b/src/Behavioural/Observer/Notifications/NotifySubject.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace levijackson\Pattern\Behavioural\Observer\Notifications;
+
+use SplSubject;
+use SplObserver;
+
+class NotifySubject implements SplSubject {
+
+    protected array $observers = [];
+
+    public function attach(SplObserver $observer): void {
+        $observerId = $this->getObserverId($observer);
+        $this->observers[$observerId] = $observer;
+    }
+   
+    public function detach(SplObserver $observer): void {
+        $observerId = $this->getObserverId($observer);
+
+        if (isset($this->observers[$observerId])) {
+            unset($this->observers[$observerId]);
+        }
+    }
+
+    public function notify(): void {
+        foreach ($this->observers as $observer) {
+            $observer->update($this);
+        }
+    }
+
+    protected function getObserverId(SplObserver $observer): string {
+        return get_class($observer);
+    }
+}

--- a/src/Behavioural/Observer/Notifications/README.md
+++ b/src/Behavioural/Observer/Notifications/README.md
@@ -1,2 +1,1 @@
-The backstory here is that we want to get notified of issues. The service that handles alerting will subscribe to the appropriate notifier.
-
+The backstory here is that we want to get notified of issues. We have email and Slack available as options. The service using the notifier will choose which is the approiate delivery option. In some cases it may use multiple.

--- a/src/Behavioural/Observer/Notifications/README.md
+++ b/src/Behavioural/Observer/Notifications/README.md
@@ -1,1 +1,1 @@
-The backstory here is that we want to get notified of issues. We have email and Slack available as options. The service using the notifier will choose which is the approiate delivery option. In some cases it may use multiple.
+The backstory here is that we want to get notified of issues. We have email and Slack available as options. The service using the notifier will choose which is the appropriate delivery option. In some cases it may use multiple.

--- a/src/Behavioural/Observer/Notifications/README.md
+++ b/src/Behavioural/Observer/Notifications/README.md
@@ -1,0 +1,2 @@
+The backstory here is that we want to get notified of issues. The service that handles alerting will subscribe to the appropriate notifier.
+

--- a/src/Behavioural/Observer/Notifications/SlackObserver.php
+++ b/src/Behavioural/Observer/Notifications/SlackObserver.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace levijackson\Pattern\Behavioural\Observer\Notifications;
+
+use SplSubject;
+
+class SlackObserver extends BaseObserver {
+
+}

--- a/tests/Unit/Behavioural/Observer/Notifications/NotifySubjectTest.php
+++ b/tests/Unit/Behavioural/Observer/Notifications/NotifySubjectTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace levijackson\Pattern\Tests\Unit\Behavioural\Observer\Notifications;
 
 use levijackson\Pattern\Behavioural\Observer\Notifications\NotifySubject;
+use levijackson\Pattern\Behavioural\Observer\Notifications\BaseObserver;
 use levijackson\Pattern\Behavioural\Observer\Notifications\EmailObserver;
 use levijackson\Pattern\Behavioural\Observer\Notifications\SlackObserver;
 
@@ -19,9 +20,29 @@ class NotifySubjectTest extends TestCase {
         $subject->attach($emailObserver);
         $subject->attach($slackObserver);
 
+        $this->assertEquals(BaseObserver::STATUS_NOT_SENT, $emailObserver->getStatus());
+        $this->assertEquals(BaseObserver::STATUS_NOT_SENT, $slackObserver->getStatus());
+
         $subject->notify();
 
-        $this->assertEquals(1, $emailObserver->getStatus());
-        $this->assertEquals(1, $slackObserver->getStatus());
+        $this->assertEquals(BaseObserver::STATUS_SENT, $emailObserver->getStatus());
+        $this->assertEquals(BaseObserver::STATUS_SENT, $slackObserver->getStatus());
+    }
+
+    public function testRemoveNotifications(): void {
+        $subject = new NotifySubject();
+        $emailObserver = new EmailObserver();
+        $slackObserver = new SlackObserver();
+        $subject->attach($emailObserver);
+        $subject->attach($slackObserver);
+
+        $this->assertEquals(BaseObserver::STATUS_NOT_SENT, $emailObserver->getStatus());
+        $this->assertEquals(BaseObserver::STATUS_NOT_SENT, $slackObserver->getStatus());
+        $subject->detach($emailObserver);
+
+        $subject->notify();
+
+        $this->assertEquals(BaseObserver::STATUS_NOT_SENT, $emailObserver->getStatus());
+        $this->assertEquals(BaseObserver::STATUS_SENT, $slackObserver->getStatus());
     }
 }

--- a/tests/Unit/Behavioural/Observer/Notifications/NotifySubjectTest.php
+++ b/tests/Unit/Behavioural/Observer/Notifications/NotifySubjectTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace levijackson\Pattern\Tests\Unit\Behavioural\Observer\Notifications;
+
+use levijackson\Pattern\Behavioural\Observer\Notifications\NotifySubject;
+use levijackson\Pattern\Behavioural\Observer\Notifications\EmailObserver;
+use levijackson\Pattern\Behavioural\Observer\Notifications\SlackObserver;
+
+use PHPUnit\Framework\TestCase;
+
+class NotifySubjectTest extends TestCase {
+
+    public function testNotifications(): void {
+        $subject = new NotifySubject();
+        $emailObserver = new EmailObserver();
+        $slackObserver = new SlackObserver();
+        $subject->attach($emailObserver);
+        $subject->attach($slackObserver);
+
+        $subject->notify();
+
+        $this->assertEquals(1, $emailObserver->getStatus());
+        $this->assertEquals(1, $slackObserver->getStatus());
+    }
+}


### PR DESCRIPTION
Adding observer pattern example

**Tests**
Using https://github.com/levijackson/docker-php run the unit tests
```
APPLICATION_PATH=<local_path_to_this_repo_code> docker-compose run php vendor/bin/phpunit tests/
```